### PR TITLE
fix: Fix call AuthClient.create after logout

### DIFF
--- a/src/auth_client_demo_assets/react/use-auth-client.jsx
+++ b/src/auth_client_demo_assets/react/use-auth-client.jsx
@@ -39,11 +39,15 @@ export const useAuthClient = (options = defaultOptions) => {
   const [principal, setPrincipal] = useState(null);
   const [whoamiActor, setWhoamiActor] = useState(null);
 
-  useEffect(() => {
+  const initAuthClient = () => {
     // Initialize AuthClient
     AuthClient.create(options.createOptions).then(async (client) => {
       updateClient(client);
     });
+  }
+
+  useEffect(() => {
+    initAuthClient();
   }, []);
 
   const login = () => {
@@ -78,7 +82,7 @@ export const useAuthClient = (options = defaultOptions) => {
 
   async function logout() {
     await authClient?.logout();
-    await updateClient(authClient);
+    initAuthClient();
   }
 
   return {


### PR DESCRIPTION
Call AuthClient.create init after logout because logout undoes many required init things, mainly deletes IndexDB's identity record:

https://github.com/dfinity/agent-js/blob/d03fd4f7ae7080ece1067e454b938fef782ea37d/packages/auth-client/src/index.ts#L308-L315
```ts
        await storage.set(KEY_STORAGE_KEY, (key as ECDSAKeyIdentity).getKeyPair());
```

https://github.com/dfinity/agent-js/blob/d03fd4f7ae7080ece1067e454b938fef782ea37d/packages/auth-client/src/index.ts#L572-L576
```ts
async function _deleteStorage(storage: AuthClientStorage) {
  await storage.remove(KEY_STORAGE_KEY);
  await storage.remove(KEY_STORAGE_DELEGATION);
  await storage.remove(KEY_VECTOR);
}
```